### PR TITLE
[DEV] FE 참여게시판 리스트 UI 구성

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,11 +1,13 @@
 import { Routes, Route } from "react-router-dom";
 import "./styles/App.scss";
 import { CampaignProvider } from "./components/CampaignContext";
+import { CommentContextProvider } from "./components/CampaignComment";
 import NavBar from "./components/Navbar";
 import MainApp from "./pages/MainPage/MainApp";
 import RegisterApp from "./pages/RegisterPage/RegisterApp";
 import SearchApp from "./pages/SearchPage/SearchApp";
 import CampaignDetail from "./pages/SearchPage/CampaignDetail";
+import CampaignAuthList from "./pages/SearchPage/CampaignAuthList";
 import ProfileApp from "./pages/ProfilePage/ProfileApp";
 
 function App() {
@@ -23,6 +25,14 @@ function App() {
           <Route path="/register" element={<RegisterApp />} />
           <Route path="/search" element={<SearchApp />} />
           <Route path="/campaigns/:campaignId" element={<CampaignDetail />} />
+          <Route
+            path="/campaigns/:campaignId/participations"
+            element={
+              <CommentContextProvider>
+                <CampaignAuthList />
+              </CommentContextProvider>
+            }
+          />
           <Route path="/profile" element={<ProfileApp />} />
         </Route>
       </Routes>

--- a/src/components/CampaignComment.js
+++ b/src/components/CampaignComment.js
@@ -1,0 +1,152 @@
+import { createContext, useState } from "react";
+
+const virtualComments = [
+  {
+    joinCount: 455,
+    totalPostsCount: 1000,
+    posts: [
+      {
+        postId: "1",
+        content: "줍깅 참여완료~",
+        nickname: "셔니",
+        profileImageUrl:
+          "https://img.freepik.com/premium-vector/green-sprout-plant-in-ground-soil-vector-icon_88813-1877.jpg",
+        postImageUrl:
+          "https://{서버주소}.s3.ap-northeast-2.amazonaws.com/{nickname}/posts/image.png",
+        date: "2023-02-04 16:12:36",
+      },
+      {
+        postId: "2",
+        content: "줍깅 참여완료~",
+        nickname: "셔니",
+        profileImageUrl:
+          "https://img.freepik.com/premium-vector/green-sprout-plant-in-ground-soil-vector-icon_88813-1877.jpg",
+        postImageUrl:
+          "https://{서버주소}.s3.ap-northeast-2.amazonaws.com/{nickname}/posts/image.png",
+        date: "2023-02-04 16:12:36",
+      },
+      {
+        postId: "3",
+        content: "줍깅 참여완료~",
+        nickname: "셔니",
+        profileImageUrl:
+          "https://img.freepik.com/premium-vector/green-sprout-plant-in-ground-soil-vector-icon_88813-1877.jpg",
+        postImageUrl:
+          "https://{서버주소}.s3.ap-northeast-2.amazonaws.com/{nickname}/posts/image.png",
+        date: "2023-02-04 16:12:36",
+      },
+      {
+        postId: "4",
+        content: "줍깅 참여완료~",
+        nickname: "셔니",
+        profileImageUrl:
+          "https://img.freepik.com/premium-vector/green-sprout-plant-in-ground-soil-vector-icon_88813-1877.jpg",
+        postImageUrl:
+          "https://{서버주소}.s3.ap-northeast-2.amazonaws.com/{nickname}/posts/image.png",
+        date: "2023-02-04 16:12:36",
+      },
+      {
+        postId: "5",
+        content: "줍깅 참여완료~",
+        nickname: "셔니",
+        profileImageUrl:
+          "https://img.freepik.com/premium-vector/green-sprout-plant-in-ground-soil-vector-icon_88813-1877.jpg",
+        postImageUrl:
+          "https://{서버주소}.s3.ap-northeast-2.amazonaws.com/{nickname}/posts/image.png",
+        date: "2023-02-04 16:12:36",
+      },
+      {
+        postId: "6",
+        content: "줍깅 참여완료~",
+        nickname: "셔니",
+        profileImageUrl:
+          "https://img.freepik.com/premium-vector/green-sprout-plant-in-ground-soil-vector-icon_88813-1877.jpg",
+        postImageUrl:
+          "https://{서버주소}.s3.ap-northeast-2.amazonaws.com/{nickname}/posts/image.png",
+        date: "2023-02-04 16:12:36",
+      },
+      {
+        postId: "7",
+        content: "줍깅 참여완료~",
+        nickname: "셔니",
+        profileImageUrl:
+          "https://img.freepik.com/premium-vector/green-sprout-plant-in-ground-soil-vector-icon_88813-1877.jpg",
+        postImageUrl:
+          "https://{서버주소}.s3.ap-northeast-2.amazonaws.com/{nickname}/posts/image.png",
+        date: "2023-02-04 16:12:36",
+      },
+      {
+        postId: "8",
+        content: "줍깅 참여완료~",
+        nickname: "셔니",
+        profileImageUrl:
+          "https://img.freepik.com/premium-vector/green-sprout-plant-in-ground-soil-vector-icon_88813-1877.jpg",
+        postImageUrl:
+          "https://{서버주소}.s3.ap-northeast-2.amazonaws.com/{nickname}/posts/image.png",
+        date: "2023-02-04 16:12:36",
+      },
+      {
+        postId: "9",
+        content: "줍깅 참여완료~",
+        nickname: "셔니",
+        profileImageUrl:
+          "https://img.freepik.com/premium-vector/green-sprout-plant-in-ground-soil-vector-icon_88813-1877.jpg",
+        postImageUrl:
+          "https://{서버주소}.s3.ap-northeast-2.amazonaws.com/{nickname}/posts/image.png",
+        date: "2023-02-04 16:12:36",
+      },
+      {
+        postId: "10",
+        content: "줍깅 참여완료~",
+        nickname: "셔니10",
+        profileImageUrl:
+          "https://img.freepik.com/premium-vector/green-sprout-plant-in-ground-soil-vector-icon_88813-1877.jpg",
+        postImageUrl:
+          "https://{서버주소}.s3.ap-northeast-2.amazonaws.com/{nickname}/posts/image.png",
+        date: "2023-02-04 16:12:36",
+      },
+      {
+        postId: "11",
+        content: "줍깅 참여완료~",
+        nickname: "셔니11",
+        profileImageUrl:
+          "https://img.freepik.com/premium-vector/green-sprout-plant-in-ground-soil-vector-icon_88813-1877.jpg",
+        postImageUrl:
+          "https://{서버주소}.s3.ap-northeast-2.amazonaws.com/{nickname}/posts/image.png",
+        date: "2023-02-04 16:12:36",
+      },
+      {
+        postId: "12",
+        content: "줍깅 참여완료~",
+        nickname: "셔니12",
+        profileImageUrl:
+          "https://img.freepik.com/premium-vector/green-sprout-plant-in-ground-soil-vector-icon_88813-1877.jpg",
+        postImageUrl:
+          "https://{서버주소}.s3.ap-northeast-2.amazonaws.com/{nickname}/posts/image.png",
+        date: "2023-02-04 16:12:36",
+      },
+      {
+        postId: "13",
+        content: "줍깅 참여완료~",
+        nickname: "셔니13",
+        profileImageUrl:
+          "https://img.freepik.com/premium-vector/green-sprout-plant-in-ground-soil-vector-icon_88813-1877.jpg",
+        postImageUrl:
+          "https://{서버주소}.s3.ap-northeast-2.amazonaws.com/{nickname}/posts/image.png",
+        date: "2023-02-04 16:12:36",
+      },
+    ],
+  },
+];
+
+export const CommentContext = createContext();
+
+export const CommentContextProvider = ({ children }) => {
+  const [comments, setComments] = useState(virtualComments);
+
+  return (
+    <CommentContext.Provider value={{ comments }}>
+      {children}
+    </CommentContext.Provider>
+  );
+};

--- a/src/components/HeaderContainer.js
+++ b/src/components/HeaderContainer.js
@@ -1,0 +1,13 @@
+import styled from "styled-components";
+
+export const HeaderContainer = styled.div`
+  width: 100%;
+  max-width: 375px;
+  height: 3rem;
+  background: white;
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  display: flex;
+  align-items: center;
+`;

--- a/src/pages/RegisterPage/RegisterApp.js
+++ b/src/pages/RegisterPage/RegisterApp.js
@@ -1,20 +1,9 @@
 // 캠페인 등록 페이지
 import Header from "../../components/Header";
 import RegisterForm from "./RegisterForm";
-import styled from "styled-components";
+import { HeaderContainer } from "../../components/HeaderContainer";
 
 const RegisterApp = () => {
-  const HeaderContainer = styled.div`
-    width: 100%;
-    max-width: 375px;
-    height: 3rem;
-    background: white;
-    position: sticky;
-    top: 0;
-    z-index: 1;
-    display: flex;
-    align-items: center;
-  `;
   return (
     <div>
       <HeaderContainer>

--- a/src/pages/SearchPage/CampaignAuthList.js
+++ b/src/pages/SearchPage/CampaignAuthList.js
@@ -1,0 +1,106 @@
+// 캠페인 인증 페이지
+import { useContext, useEffect, useState, useRef } from "react";
+import { useParams, useNavigate } from "react-router-dom";
+import "../../styles/SearchPage/CampaignAuthList.scss";
+import { CampaignContext } from "../../components/CampaignContext";
+import { CommentContext } from "../../components/CampaignComment";
+import { HeaderContainer } from "../../components/HeaderContainer";
+import Header from "../../components/Header";
+
+const CampaignAuthList = () => {
+  const { campaignId } = useParams();
+  const { campaigns } = useContext(CampaignContext);
+  const campaign = campaigns.find((c) => c.id === parseInt(campaignId));
+  const { comments } = useContext(CommentContext);
+  const navigate = useNavigate();
+
+  const [visibleComments, setVisibleComments] = useState(10);
+  const observerRef = useRef(null);
+
+  useEffect(() => {
+    const options = {
+      root: null,
+      rootMargin: "0px",
+      threshold: 0.9, // 댓글이 화면의 90%이상 드러날 때 추가 댓글 불러오기
+    };
+
+    const observer = new IntersectionObserver((entries) => {
+      entries.forEach((entry) => {
+        if (entry.isIntersecting) {
+          setVisibleComments((prev) => prev + 10);
+        }
+      });
+    }, options);
+    if (observerRef.current) {
+      observer.observe(observerRef.current);
+    }
+
+    return () => {
+      if (observerRef.current) {
+        observer.unobserve(observerRef.current);
+      }
+    };
+  }, [comments]);
+
+  const handleScroll = () => {
+    const scrollY = window.scrollY;
+    const totalHeight = document.documentElement.scrollHeight;
+    const clientHeight = document.documentElement.clientHeight;
+    if (scrollY + clientHeight >= totalHeight * 1.0) {
+      setVisibleComments((prev) => prev + 10);
+    }
+  };
+
+  useEffect(() => {
+    window.addEventListener("scroll", handleScroll);
+    return () => {
+      window.removeEventListener("scroll", handleScroll);
+    };
+  }, []);
+
+  if (!campaign || !comments) {
+    return <div>캠페인 불러오는중...</div>;
+  }
+
+  const { joinCount, totalPostsCount, posts } = comments[0];
+
+  const handleWritePost = () => {
+    navigate(`/campaigns/${campaignId}/participations/post`);
+  };
+
+  return (
+    <div>
+      <HeaderContainer>
+        <Header menuTitle={campaign.title} />
+      </HeaderContainer>
+      <div className="participation-number">
+        <p>
+          <span>{joinCount}</span>명이 <span>{totalPostsCount}</span>번
+          참여했어요.
+        </p>
+      </div>
+      <div className="participation-comments">
+        {posts.slice(0, visibleComments).map((post) => (
+          <div className="participation-comment" key={post.postId}>
+            <div>
+              <img src={post.profileImageUrl} alt="profileImg" />
+            </div>
+            <div className="comment-info">
+              <div>
+                <p>{post.nickname}</p>
+                <p>{post.date}</p>
+              </div>
+              <p>{post.content}</p>
+            </div>
+            <div ref={observerRef} className="observer-element" />
+          </div>
+        ))}
+      </div>
+      <div className="participation-button">
+        <button onClick={handleWritePost}>참여인증</button>
+      </div>
+    </div>
+  );
+};
+
+export default CampaignAuthList;

--- a/src/pages/SearchPage/CampaignDetail.js
+++ b/src/pages/SearchPage/CampaignDetail.js
@@ -1,24 +1,12 @@
 // 캠페인 상세 페이지
 import { useContext } from "react";
 import { useParams, useNavigate } from "react-router-dom";
-import styled from "styled-components";
+import { HeaderContainer } from "../../components/HeaderContainer";
 import { CampaignContext } from "../../components/CampaignContext";
 import Header from "../../components/Header";
 import "../../styles/SearchPage/CampaignDetail.scss";
 
 const CampaignDetail = () => {
-  const HeaderContainer = styled.div`
-    width: 100%;
-    max-width: 375px;
-    height: 3rem;
-    background: white;
-    position: sticky;
-    top: 0;
-    z-index: 1;
-    display: flex;
-    align-items: center;
-  `;
-
   const { campaignId } = useParams();
   const { campaigns } = useContext(CampaignContext);
   const navigate = useNavigate();

--- a/src/pages/SearchPage/SearchApp.js
+++ b/src/pages/SearchPage/SearchApp.js
@@ -1,24 +1,12 @@
 // 돋보기 메뉴(검색) 페이지 - 검색창 및 최신 캠페인 보여주기
 import Header from "../../components/Header";
 import "../../styles/SearchPage/SearchApp.scss";
-import styled from "styled-components";
 import { useNavigate } from "react-router-dom";
 import { useContext, useState } from "react";
 import { CampaignContext } from "../../components/CampaignContext";
+import { HeaderContainer } from "../../components/HeaderContainer";
 
 const SearchApp = () => {
-  const HeaderContainer = styled.div`
-    width: 100%;
-    max-width: 375px;
-    height: 3rem;
-    background: white;
-    position: sticky;
-    top: 0;
-    z-index: 1;
-    display: flex;
-    align-items: center;
-  `;
-
   const { campaigns } = useContext(CampaignContext);
   const navigate = useNavigate();
   const goDetailCampaign = (campaignId) => {

--- a/src/styles/SearchPage/CampaignAuthList.scss
+++ b/src/styles/SearchPage/CampaignAuthList.scss
@@ -1,0 +1,77 @@
+.participation-number {
+  width: 340px;
+  height: 40px;
+  border-radius: 15px;
+  background: #9dc99c;
+  margin: 0 auto;
+  margin-top: 16px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  p {
+    span {
+      color: #07683a;
+    }
+  }
+}
+
+.participation-comments {
+  width: 330px;
+  padding: 20px;
+  margin-top: 16px;
+  .participation-comment {
+    width: 100%;
+    height: 70px;
+    display: flex;
+    gap: 16px;
+    margin-bottom: 16px;
+    img {
+      width: 45px;
+      height: 45px;
+    }
+
+    .comment-info {
+      width: 100%;
+      border-bottom: 1px solid #e8e8e8;
+      div {
+        display: flex;
+        justify-content: space-between;
+        margin-bottom: 16px;
+
+        :nth-child(1) {
+          font-size: 16px;
+          font-weight: 600;
+        }
+
+        :nth-child(2) {
+          color: #bdbdbd;
+          font-size: 14px;
+          font-weight: 400;
+        }
+      }
+      p {
+        font-size: 14px;
+        font-weight: 400;
+        margin: 0;
+      }
+    }
+  }
+}
+
+.participation-button {
+  width: 340px;
+  text-align: center;
+  position: fixed;
+  bottom: 7.3vh;
+  background: rgba(255, 255, 255, 0.9);
+  padding: 10px 20px;
+  button {
+    border: none;
+    background: #5db075;
+    border-radius: 25px;
+    color: #ffffff;
+    font-weight: 700;
+    padding: 16px 32px;
+  }
+}


### PR DESCRIPTION
## Summary
캠페인 참여게시판 리스트 UI 작성

## Description
- 캠페인 상세보기 페이지에서 캠페인 클릭 시 참여 인증 글들 불러오기
- 참여자 수, 인증 글 갯수 상단에 출력
- 캠페인 인증 글들 10개씩 무한 스크롤로 출력
- 페이지 하단 "참여인증" 버튼 누르면 캠페인 인증 작성할 수 있는 페이지로 이동

![image](https://github.com/devocean-green-dev/GreenDev_FE/assets/88546743/23353cf5-35eb-4f67-ab54-0aa0aebdb020)


